### PR TITLE
create a shared function and add null check when line number is null

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -15,7 +15,7 @@ function activate(context) {
         statusBarItem.text = "Codealike is initializing...";
 
         // initialize plugin for current client and version
-        Codealike.initialize('vscode', '0.0.25');
+        Codealike.initialize('vscode', '0.0.26');
 
         Codealike.registerStateSubscriber((state) => {
             if (state.isTracking) {
@@ -137,20 +137,50 @@ function startTrackingProject() {
         Codealike.trackCodingState();
     });
 
-    vscode.workspace.onDidChangeTextDocument((event) => {
-        //let lineAt = null;
-        //if (event.contentChanges.length) {
-        //    lineAt = event.document.positionAt().line;
-        //}
+    //Given an input line and results , find the corresponding class and symbol   
+    function _findClassAndMember(results ,line) {
+        const clsSymbol = {
+            className: null,
+            member: null
+        }
 
+        if (!results || !line) {
+            return clsSymbol;
+        }
+
+        results.forEach(element => {
+            if (!element) return;
+            if (!element.location || !element.location.range) return;
+            if (!element.location.range._start?.line) {
+               return; 
+            }
+            const rangeLine = element.location.range._start.line;
+            if (rangeLine > line) {
+                return;
+            }
+            if (element.kind == vscode.SymbolKind.Class) {
+                clsSymbol.className = element.name;
+            }
+            if (element.kind == vscode.SymbolKind.Method) {
+                clsSymbol.member = element.name;
+            }
+        });
+        return clsSymbol;
+    }
+
+    vscode.workspace.onDidChangeTextDocument((event) => {
+       
         vscode
             .commands
             .executeCommand('vscode.executeDocumentSymbolProvider', event.document.uri)
             .then(function(result) {
+                
                 if (!event.contentChanges || event.contentChanges.length == 0)
                     return;
 
-                var line = event.contentChanges[0].range.start.line;
+                var line = event.contentChanges[0]?.range?.start?.line;
+
+                /* OLD CODE COMMENTED AND MOVED TO COMMON FUNCTION
                 var className = null;
                 var member = null;
 
@@ -167,13 +197,15 @@ function startTrackingProject() {
                             member = element.name;
                         }
                     }, this);
-                }
+                }*/
+
+                const clsSymbol = _findClassAndMember(result, line);
 
                 let context = {
                     file: event.document.fileName,
                     line: line,
-                    className: className,
-                    member: member
+                    className: clsSymbol.className, //className,
+                    member: clsSymbol.member //member
                 }
 
                 Codealike.trackCodingEvent(context);
@@ -194,11 +226,13 @@ function startTrackingProject() {
                     if (!event.selections || event.selections.length == 0)
                         return;
 
-                    var line = event.selections[0].active.line;
+                    var line = event.selections[0]?.active?.line;
+
+                    /* OLD CODE COMMENTED AND MOVED TO COMMON FUNCTION
                     var className = null;
                     var member = null;
 
-                    if (result) {
+                    if (result) { 
                         result.forEach(function(element) {
                             if (!element || element.location.range._start.line > line)
                                 return;
@@ -211,13 +245,15 @@ function startTrackingProject() {
                                 member = element.name;
                             }
                         }, this);
-                    }
+                    } */
+
+                    const clsSymbol = _findClassAndMember(result, line);
 
                     let context = {
                         file: event.textEditor.document.fileName,
                         line: line,
-                        className: className,
-                        member: member
+                        className: clsSymbol.className, //className,
+                        member: clsSymbol.member //member
                     }
 
                     Codealike.trackFocusEvent(context);


### PR DESCRIPTION
Add null checks to prevent errors in accessing the line variable. Usually happens when the user enters blank lines on a file.